### PR TITLE
Match label on AKS nodes

### DIFF
--- a/src/application/ingress/mandatory.yaml
+++ b/src/application/ingress/mandatory.yaml
@@ -214,7 +214,7 @@ spec:
       terminationGracePeriodSeconds: 300
       serviceAccountName: nginx-ingress-serviceaccount
       nodeSelector:
-        kubernetes.io/os: linux
+        beta.kubernetes.io/os: linux
       containers:
         - name: nginx-ingress-controller
           image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1


### PR DESCRIPTION
The nginx ingress deployment resource currently only deploys to nodes with the label: ` kubernetes.io/os: linux` label.

The AKS nodes have `beta.kubernetes.io/os: linux` label instead.

Update the nginx ingress deployment to match this label so that they can be deployed to the AKS nodes.