### PR TITLE
Add cluster issuer for letsencrypt staging server

### DIFF
--- a/src/application/cert-manager/cluster-issuer.yml
+++ b/src/application/cert-manager/cluster-issuer.yml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: oliver.wheeler@microsoft.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource used to store the account's private key.
+      name: letsencrypt-staging
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx


### PR DESCRIPTION
To as described [here](https://docs.cert-manager.io/en/latest/tutorials/acme/quick-start/index.html#step-6-configure-let-s-encrypt-issuer) but used ClusterIssuer instead of Issuer